### PR TITLE
Added level to slackbot notifications for goals that have a level set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,11 +161,20 @@ function shouldDueDateNotificationBePosted(card) {
   return NOTIFICATION_TIMEFRAMES.indexOf(timeDifference) !== -1;
 }
 
+function getGoalName(card) {
+  var goalName = card.child('type').val();
+  if (card.child('level').val()) {
+    goalName += ' - Level ' + card.child('level').val();
+  }
+
+  return goalName;
+}
+
 function postPrivateNotification(card, email) {
   var timeDifference = getTimeDifferenceForCard(card);
   var slackHandle = '@' + users['@' + email].name;
-  var message = timeDifference <= 0 ? 'Your "' + card.child('type').val() + '" goal is overdue… Feel free to reach out to your Unleasher if you need any help!' :
-    'Your "' + card.child('type').val() + '" goal is due in ' + timeDifference + ' day' + (timeDifference === 1 ? '' : 's') + '… Feel free to reach out to your Unleasher if you need any help!';
+  var message = timeDifference <= 0 ? 'Your "' + getGoalName(card) + '" goal is overdue… Feel free to reach out to your Unleasher if you need any help!' :
+    'Your "' + getGoalName(card) + '" goal is due in ' + timeDifference + ' day' + (timeDifference === 1 ? '' : 's') + '… Feel free to reach out to your Unleasher if you need any help!';
 
   postNotification(card, timeDifference, {
     channel: slackHandle,
@@ -181,8 +190,8 @@ function postUnleasherNotification(card, email) {
 
   var timeDifference = getTimeDifferenceForCard(card);
   var currentUser = users['@' + email] || {};
-  var message = timeDifference <= 0 ? (currentUser.real_name || currentUser.name) + '\'s "' + card.child('type').val() + '" goal is overdue!' :
-    (currentUser.real_name || currentUser.name) + '\'s "' + card.child('type').val() + '" goal is due in ' + timeDifference + ' day' + (timeDifference === 1 ? '!' : 's!');
+  var message = timeDifference <= 0 ? (currentUser.real_name || currentUser.name) + '\'s "' + getGoalName(card) + '" goal is overdue!' :
+    (currentUser.real_name || currentUser.name) + '\'s "' + getGoalName(card) + '" goal is due in ' + timeDifference + ' day' + (timeDifference === 1 ? '!' : 's!');
 
   postNotification(card, timeDifference, {
     channel: config.unleasherChannel,


### PR DESCRIPTION
Today I got the following notifications from Slackbot:

> Your "Sportsman" goal is due in 7 days… Feel free to reach out to your Unleasher if you need any help!
> Your "Sportsman" goal is due in 1 day… Feel free to reach out to your Unleasher if you need any help!

It was quite confusing, I needed a moment to realise they're 2 different levels of the same goal.

This PR adds level to notifications about goals that have a level set. With this PR the notifications would look like:


> Your "Sportsman - Level 2" goal is due in 7 days… Feel free to reach out to your Unleasher if you need any help!
> Your "Sportsman - Level 1" goal is due in 1 day… Feel free to reach out to your Unleasher if you need any help!

Nothing changes for goals that have no level set.