### PR TITLE
Updated time left calculation rules so that tasks become overdue after the due date, not on due date.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ function checkDueDates() {
 }
 
 function getTimeDifferenceForCard(card) {
-  return Math.max(0, Math.floor((+new Date(card.child('dueDate').val()) - new Date()) / (1000 * 60 * 60 * 24)));
+  return Math.max(0, Math.floor((+new Date(card.child('dueDate').val()) - new Date()) / (1000 * 60 * 60 * 24)) + 1);
 }
 
 function shouldDueDateNotificationBePosted(card) {


### PR DESCRIPTION
Today in the morning I got the following notification:

> Your "Sportsman" goal is overdue

even though the due date is today.

IMO the days left are calculated incorrectly as they don't include the day on the due date. If I set the due date to tomorrow, then I plan to achieve the goal tomorrow latest, so the goal is overdue only on the day after tomorrow and later.

This PR adds that missing day to the calculated days left.